### PR TITLE
Make missing out-of-plane bends a catchable error.

### DIFF
--- a/include/libirc/connectivity.h
+++ b/include/libirc/connectivity.h
@@ -1061,8 +1061,7 @@ std::vector<Dihedral> dihedrals(const Matrix& distance_m,
 
   // Check if dihedrals are found
   if (n_atoms >= 4 && dih.empty()) {
-    std::cerr << "ERROR: Out of plane bending not implemented yet."
-              << std::endl << std::flush;
+    throw std::runtime_error("ERROR: Out of plane bending not implemented yet.");
   }
 
   // Return list of dihedral angles


### PR DESCRIPTION
Just a quick fix for convenience, the title and diff should say it all.