### PR TITLE
CMake: Fix missing libirc.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,12 @@ endif()
 # | TESTING |
 # + ------- +
 
-enable_testing()
-add_subdirectory(external)
-add_subdirectory(src/test)
+option(BUILD_TESTS "Build tests for the library" ON)
+if(BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(external)
+  add_subdirectory(src/test)
+endif()
 
 # + ------------ +
 # | INSTALLATION |
@@ -118,7 +121,7 @@ add_subdirectory(src/test)
 
 # Copy headers folder
 install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/libirc
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
   DESTINATION include
 )
 # Create an export set

--- a/include/libirc/linalg.h
+++ b/include/libirc/linalg.h
@@ -4,9 +4,9 @@
 #ifdef HAVE_ARMA
 #include <armadillo>
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
-#include <eigen3/Eigen/Geometry>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Dense>
+#include <Eigen/Geometry>
+#include <Eigen/LU>
 #else
 #error
 #endif


### PR DESCRIPTION
Sorry to bother you with CMake stuff again, but I noticed a mistake I made and couldn't let it go uncorrected.

The helper include file `libirc.h` isn't currently installed because of a path mistake I made. I added that.

I also added another `option` regarding building the tests, which is on by default. This allows people who use the package via `Download_project` and `add_subdirectory` to disable the tests in their builds if they so choose.