### PR TITLE
Fix missed eigen includes from tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 
 # Copy headers folder
 install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
   DESTINATION include
 )
 # Create an export set

--- a/src/test/atom_test.cpp
+++ b/src/test/atom_test.cpp
@@ -11,7 +11,7 @@
 #include <armadillo>
 using arma::vec3;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 #else
 #error

--- a/src/test/connectivity_test.cpp
+++ b/src/test/connectivity_test.cpp
@@ -20,7 +20,7 @@ using mat = arma::mat;
 template<typename T>
 using Mat = arma::Mat<T>;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 using vec = Eigen::VectorXd;
 using mat = Eigen::MatrixXd;

--- a/src/test/io_test.cpp
+++ b/src/test/io_test.cpp
@@ -10,7 +10,7 @@ using arma::mat;
 using arma::vec;
 using arma::vec3;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 using vec = Eigen::VectorXd;
 using mat = Eigen::MatrixXd;

--- a/src/test/irc_test.cpp
+++ b/src/test/irc_test.cpp
@@ -17,7 +17,7 @@ using mat = arma::mat;
 template<typename T>
 using Mat = arma::Mat<T>;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 using vec = Eigen::VectorXd;
 using mat = Eigen::MatrixXd;

--- a/src/test/linalg_test.cpp
+++ b/src/test/linalg_test.cpp
@@ -8,7 +8,7 @@ using vec3 = arma::vec3;
 using vec = arma::vec;
 using mat = arma::mat;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 using vec = Eigen::VectorXd;
 using mat = Eigen::MatrixXd;

--- a/src/test/mathtools_test.cpp
+++ b/src/test/mathtools_test.cpp
@@ -12,7 +12,7 @@ using mat = arma::mat;
 template<typename T>
 using Mat = arma::Mat<T>;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 using vec = Eigen::VectorXd;
 using mat = Eigen::MatrixXd;

--- a/src/test/molecule_test.cpp
+++ b/src/test/molecule_test.cpp
@@ -11,7 +11,7 @@
 #include <armadillo>
 using arma::vec3;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 #else
 #error

--- a/src/test/transformation_test.cpp
+++ b/src/test/transformation_test.cpp
@@ -20,7 +20,7 @@ using mat = arma::mat;
 template<typename T>
 using Mat = arma::Mat<T>;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 using vec = Eigen::VectorXd;
 using mat = Eigen::MatrixXd;

--- a/src/test/wilson_test.cpp
+++ b/src/test/wilson_test.cpp
@@ -18,7 +18,7 @@ using vec3 = arma::vec3;
 using vec = arma::vec;
 using mat = arma::mat;
 #elif HAVE_EIGEN3
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 using vec3 = Eigen::Vector3d;
 using vec = Eigen::VectorXd;
 using mat = Eigen::MatrixXd;


### PR DESCRIPTION
I forgot the tests when adapting the eigen include path in `libdir/linalg.h` to the correct relative include path set by the `Eigen3::Eigen` target :facepalm: 